### PR TITLE
Fix crash when setting parameters with value zero

### DIFF
--- a/src/hardware/spikey/__init__.py
+++ b/src/hardware/spikey/__init__.py
@@ -1049,7 +1049,7 @@ def set(cells, cellclass, param, val=None):
     global _neuronsChanged
     global _inputChanged
 
-    if val:
+    if not val is None:
         param = {param: val}
     if type(cells) != types.ListType:
         cells = [cells]


### PR DESCRIPTION
When calling tset/set with a zero parameter, the program crashes with an exception, e.g.

```
pop.tset("tau_refrac", [0.0, 0.0, 0.0, 0.0])
```

crashes with

```
Exception: ERROR: Cell 0 has no parameter t!
```

This patch fixes this problem by explicitly checking whether
the value is "None" (the default parameter value) and not
blindly converting the value to a boolean expression.
